### PR TITLE
Fix: Resolved the case for not divisible numbers.

### DIFF
--- a/R/lttb.R
+++ b/R/lttb.R
@@ -44,7 +44,7 @@ LTTB = function(data, n_bins) {
   }
 
   N = nrow(data)
-  bin_width = (N - 2) / n_bins
+  bin_width = floor((N - 2) / n_bins)
   
   if (N <= n_bins + 2) {
     return(data)


### PR DESCRIPTION
I had some problem with a dataset of 944312 elements when producing 2000 points. They're not divisible so it was having some issues (e.g. crashing every time). This fixed it.